### PR TITLE
Fix directory message exceeding 4000-char content limit

### DIFF
--- a/services/hall_of_fame.py
+++ b/services/hall_of_fame.py
@@ -1111,10 +1111,30 @@ class HallOfFame(Extension):
             else:
                 directory_lines.append(f"- {name}")
 
-        directory_body = "\n".join(directory_lines) if directory_lines else "- No Hall of Fame bosses configured yet."
+        if not directory_lines:
+            directory_lines = ["- No Hall of Fame bosses configured yet."]
+
+        # A single TextDisplayComponent content field is capped at 4000 chars.
+        # Groups with many bosses can exceed this, so we chunk the lines into
+        # multiple TextDisplayComponents that each fit within the limit.
+        _CONTENT_LIMIT = 3900  # leave some margin
+        header = "## Hall of Fame Directory\n"
+        body_components: List[BaseComponent] = []
+        current_chunk = header
+        for line in directory_lines:
+            candidate = (current_chunk + line + "\n")
+            if len(candidate) > _CONTENT_LIMIT and len(current_chunk) > len(header):
+                # Flush the current chunk and start a new one (no repeated header)
+                body_components.append(TextDisplayComponent(content=current_chunk.rstrip("\n")))
+                current_chunk = line + "\n"
+            else:
+                current_chunk = candidate
+        if current_chunk.strip():
+            body_components.append(TextDisplayComponent(content=current_chunk.rstrip("\n")))
+
         container = ContainerComponent(
             SeparatorComponent(divider=True),
-            TextDisplayComponent(content=f"## Hall of Fame Directory\n{directory_body}"),
+            *body_components,
             SeparatorComponent(divider=True),
         )
         return [container]


### PR DESCRIPTION
Groups with many bosses (e.g. group 177) produced a directory body that exceeded Discord's 4000-character limit on a single TextDisplayComponent content field, causing a 400 error on every directory post/edit.

The directory lines are now chunked: each TextDisplayComponent is filled line-by-line up to a 3900-char safety margin.  When adding the next line would exceed the limit, the current chunk is flushed and a new component is started (without repeating the header).  All chunks are placed inside a single ContainerComponent, so the directory remains one Discord message regardless of how many bosses are configured.