### PR TITLE
fix: handle wom GroupDetail schema variations

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -18,7 +18,7 @@ from db.models import GroupEmbed, GroupPatreon, GroupRecentDrops, NotificationQu
 from services import message_handler
 from services.components import help_components
 from services.points import award_points_to_player
-from utils.format import format_time_since_update, format_number, get_command_id, get_npc_image_url, replace_placeholders
+from utils.format import format_time_since_update, format_number, get_command_id, get_npc_image_url, replace_placeholders, normalize_player_display_equivalence
 from utils.wiseoldman import check_user_by_id, check_user_by_username, check_group_by_id, fetch_group_members
 from utils.redis import RedisClient
 from db.ops import DatabaseOperations, associate_player_ids
@@ -340,18 +340,64 @@ class UserCommands(Extension):
             group = session.query(Group).filter(Group.guild_id.ilike(guild_id)).first()
         if not group:
             group = session.query(Group).filter_by(group_id=2).first()
+        rsn = str(rsn).strip()
         player = session.query(Player).filter(Player.player_name.ilike(rsn)).first()
+        wom_player = None
+        wom_player_id = None
+        wom_player_name = rsn
+        log_slots = 0
+        try:
+            wom_data = await check_user_by_username(rsn)
+            if wom_data:
+                wom_player, wom_player_name, wom_player_id, log_slots = wom_data
+        except Exception as e:
+            print("Couldn't get WOM player data. e:", e)
+            wom_player = None
+
+        # Prefer WOM-authoritative identity when available and reconcile stale local rows.
+        if wom_player and wom_player_id not in (None, "", 0):
+            try:
+                wom_player_id = int(wom_player_id)
+            except (TypeError, ValueError):
+                wom_player_id = None
+            if wom_player_id is not None:
+                player_by_wom = session.query(Player).filter(Player.wom_id == wom_player_id).first()
+                if player_by_wom:
+                    player = player_by_wom
+                elif player and int(player.wom_id or 0) != wom_player_id:
+                    try:
+                        existing_conflict = session.query(Player).filter(Player.wom_id == wom_player_id).first()
+                        if existing_conflict and existing_conflict.player_id != player.player_id:
+                            player = existing_conflict
+                        else:
+                            player.wom_id = wom_player_id
+                            session.commit()
+                    except Exception:
+                        session.rollback()
+                if player:
+                    desired_name = str(wom_player_name or rsn)
+                    changed = False
+                    if normalize_player_display_equivalence(player.player_name or "") != normalize_player_display_equivalence(desired_name):
+                        player.player_name = desired_name
+                        changed = True
+                    if log_slots is not None and int(log_slots) >= 0 and int(player.log_slots or 0) != int(log_slots):
+                        player.log_slots = int(log_slots)
+                        changed = True
+                    if changed:
+                        try:
+                            session.commit()
+                        except Exception:
+                            session.rollback()
         ## User should be made now
         if not player:
-            try:
-                wom_data = await check_user_by_username(rsn)
-            except Exception as e:
-                print("Couldn't get player data. e:", e)
+            if not wom_player:
                 return await ctx.send(f"An error occurred claiming your account.\n" +
                                       "Try again later, or reach out in our Discord server",
                                       ephemeral=True)
-            if wom_data:
-                player, player_name, player_id, log_slots = wom_data
+            if wom_player:
+                player = wom_player
+                player_name = str(wom_player_name or rsn)
+                player_id = wom_player_id
                 try:
                     print("Creating a player with user ID", user.user_id, "associated with it")
                     ## We need to create the Player with a temporary acc hash for now

--- a/data/submissions/common.py
+++ b/data/submissions/common.py
@@ -138,6 +138,89 @@ async def get_wom_user_cached(player_name: str):
     return value
 
 
+def _to_int_or_none(value):
+    try:
+        if value in (None, "", 0):
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_total_level_from_wom_player(wom_player) -> int:
+    try:
+        overall = wom_player.latest_snapshot.data.skills.get("overall")
+        return int(overall.level)
+    except Exception:
+        return 0
+
+
+def _apply_authoritative_wom_identity(
+    db_session,
+    player: Player | None,
+    expected_wom_id: int | None,
+    *,
+    canonical_name: str | None = None,
+    total_level: int | None = None,
+    log_slots: int | None = None,
+    account_hash: str | None = None,
+):
+    """
+    Ensure the local player row reflects WOM's authoritative identity.
+
+    Returns:
+        tuple[player|None, bool]: (possibly replaced canonical player, changed_flag)
+    """
+    if player is None or expected_wom_id is None:
+        return player, False
+
+    changed = False
+    current_wom_id = _to_int_or_none(getattr(player, "wom_id", None))
+    if current_wom_id != expected_wom_id:
+        canonical = (
+            db_session.query(Player)
+            .filter(Player.wom_id == expected_wom_id)
+            .first()
+        )
+        if canonical and canonical.player_id != player.player_id:
+            player = canonical
+        else:
+            player.wom_id = expected_wom_id
+            changed = True
+
+    if canonical_name and normalize_player_display_equivalence(player.player_name or "") != normalize_player_display_equivalence(canonical_name):
+        player.player_name = canonical_name
+        changed = True
+
+    if total_level is not None and int(total_level) > 0 and int(player.total_level or 0) != int(total_level):
+        player.total_level = int(total_level)
+        changed = True
+
+    if log_slots is not None and int(log_slots) >= 0 and player.log_slots != int(log_slots):
+        player.log_slots = int(log_slots)
+        changed = True
+
+    if account_hash:
+        account_hash = str(account_hash)
+        if not player.account_hash:
+            existing_hash_owner = (
+                db_session.query(Player)
+                .filter(Player.account_hash == account_hash)
+                .first()
+            )
+            if (
+                existing_hash_owner
+                and existing_hash_owner.player_id != player.player_id
+                and _to_int_or_none(existing_hash_owner.wom_id) != expected_wom_id
+            ):
+                existing_hash_owner.account_hash = None
+                changed = True
+            player.account_hash = account_hash
+            changed = True
+
+    return player, changed
+
+
 class SubmissionResponse:
     """Response object for API submission endpoints.
 
@@ -341,120 +424,108 @@ async def ensure_player_and_auth(session, player_name, account_hash, auth_key):
 
     await asyncio.sleep(0)
 
-    # 1) Deterministic primary lookup: account hash.
+    # 1) Deterministic local lookups.
     player_by_hash = None
     if account_hash:
         player_by_hash = session.query(Player).filter(Player.account_hash == account_hash).first()
 
-    player = player_by_hash
+    player_by_name_fast = session.query(Player).filter(Player.player_name == player_name).first()
+    player = player_by_hash or player_by_name_fast
     resolved_by_name = False
     expected_wom_id = None
     wom_log_slots = None
+    wom_total_level = None
 
-    # 2) Fast local fallback by name to avoid unnecessary WOM calls for known players.
-    player_by_name_fast = None
-    if not player:
-        player_by_name_fast = session.query(Player).filter(Player.player_name == player_name).first()
-        if player_by_name_fast and player_by_name_fast.account_hash:
-            player = player_by_name_fast
-
-    # 3) If still unresolved, resolve identity via live WOM lookup and WOM ID.
-    if not player:
+    # 2) Authoritative WOM identity lookup for this RSN.
+    wom_player = None
+    canonical_name = player_name
+    try:
         # Release any open transaction before awaiting external API.
         try:
             session.rollback()
         except Exception:
             pass
         wom_player, resolved_name, wom_player_id, log_slots = await get_wom_user_cached(player_name)
-        if not wom_player or wom_player_id in (None, "", 0):
-            logger.log_sync(
-                "warning",
-                f"ensure_player_and_auth: WOM lookup failed for {player_name}; refusing name-only identity bind",
-            )
-            return None, False, False
-
-        try:
+        if wom_player and wom_player_id not in (None, "", 0):
             expected_wom_id = int(wom_player_id)
-        except (TypeError, ValueError):
-            return None, False, False
-        wom_log_slots = log_slots
+            wom_log_slots = log_slots
+            canonical_name = str(resolved_name or player_name)
+            wom_total_level = _extract_total_level_from_wom_player(wom_player)
+    except (TypeError, ValueError):
+        expected_wom_id = None
 
+    if expected_wom_id is not None:
+        # Prefer canonical WOM row over hash/name-resolved rows.
         player_by_wom = session.query(Player).filter(Player.wom_id == expected_wom_id).first()
-        player_by_name = session.query(Player).filter(Player.player_name == player_name).first()
-
         if player_by_wom:
             player = player_by_wom
-            # Keep the account hash bound to the WOM-resolved row.
-            if account_hash and not player.account_hash:
-                player.account_hash = account_hash
-                try:
-                    session.commit()
-                except Exception as e:
-                    debug_print("Error committing account hash on WOM-resolved row: " + str(e))
-                    session.rollback()
+        elif player is None:
+            player = player_by_name_fast
+            resolved_by_name = player is not None
+
+        if player is None:
+            # No local row matched: create canonical row from WOM identity.
+            total_level = wom_total_level if wom_total_level is not None else 0
+            player = Player(
+                wom_id=expected_wom_id,
+                player_name=canonical_name,
+                account_hash=account_hash if account_hash else None,
+                total_level=total_level,
+                log_slots=wom_log_slots if wom_log_slots is not None else 0,
+            )
+            try:
+                session.add(player)
+                session.commit()
+            except Exception:
+                session.rollback()
+                player = session.query(Player).filter(Player.wom_id == expected_wom_id).first()
+                if player is None:
                     return None, False, False
-            elif account_hash and player.account_hash and str(player.account_hash) != account_hash:
-                logger.log_sync(
-                    "warning",
-                    f"ensure_player_and_auth: hash mismatch for WOM {expected_wom_id}; refusing auth for {player_name}",
-                )
-                player_list[player_name] = player.player_id
-                return player, False, True
-        elif player_by_name:
-            # Name row exists but WOM ID doesn't: only safe to bind if WOM IDs agree.
-            resolved_by_name = True
-            if int(player_by_name.wom_id or 0) == expected_wom_id:
-                player = player_by_name
-            else:
-                logger.log_sync(
-                    "warning",
-                    (
-                        "ensure_player_and_auth: stale name row detected "
-                        f"(name={player_name}, stored_wom={player_by_name.wom_id}, expected_wom={expected_wom_id}); "
-                        "creating/using canonical WOM row instead"
-                    ),
-                )
+        else:
+            player, changed = _apply_authoritative_wom_identity(
+                session,
+                player,
+                expected_wom_id,
+                canonical_name=canonical_name,
+                total_level=wom_total_level,
+                log_slots=wom_log_slots,
+                account_hash=account_hash if account_hash else None,
+            )
+            if changed:
                 try:
-                    overall = wom_player.latest_snapshot.data.skills.get("overall")
-                    total_level = overall.level
-                except Exception:
-                    total_level = 0
-                player = Player(
-                    wom_id=expected_wom_id,
-                    player_name=str(resolved_name or player_name),
-                    account_hash=account_hash if account_hash else None,
-                    total_level=total_level,
-                    log_slots=wom_log_slots if wom_log_slots is not None else 0,
-                )
-                try:
-                    session.add(player)
                     session.commit()
                 except Exception as e:
+                    debug_print("Error committing WOM identity reconciliation: " + str(e))
                     session.rollback()
-                    debug_print("Error creating canonical WOM row during auth ensure: " + str(e))
-                    player = session.query(Player).filter(Player.wom_id == expected_wom_id).first()
-                    if not player:
-                        return None, False, False
-        else:
-            # Controlled fallback: no hash, no name row, no WOM row.
-            player = await create_player(player_name, account_hash, existing_session=session)
-            if not player:
-                logger.log_sync(
-                    "info",
-                    f"ensure_player_and_auth: Unable to create player after WOM resolution for {player_name}",
-                )
-                return None, False, False
+
+        # Hash conflicts are still treated as auth failures.
+        if account_hash and player and player.account_hash and str(player.account_hash) != account_hash:
+            logger.log_sync(
+                "warning",
+                f"ensure_player_and_auth: hash mismatch for WOM {expected_wom_id}; refusing auth for {player_name}",
+            )
+            player_list[player_name] = player.player_id
+            return player, False, True
+    elif not player:
+        # WOM unavailable + no deterministic local match.
+        logger.log_sync(
+            "warning",
+            f"ensure_player_and_auth: WOM lookup unavailable for {player_name}; refusing name-only bind",
+        )
+        return None, False, False
 
     if not player:
         return None, False, False
 
     if expected_wom_id is not None:
         # Keep name/log slots aligned for the canonical WOM row.
-        desired_name = player_name
+        desired_name = canonical_name or player_name
         if normalize_player_display_equivalence(player.player_name or "") != normalize_player_display_equivalence(desired_name):
             player.player_name = desired_name
         if wom_log_slots is not None and wom_log_slots >= 0 and player.log_slots != wom_log_slots:
             player.log_slots = wom_log_slots
+        if wom_total_level is not None and int(wom_total_level) > 0 and int(player.total_level or 0) != int(wom_total_level):
+            player.total_level = int(wom_total_level)
         try:
             session.commit()
         except Exception:
@@ -680,20 +751,8 @@ async def ensure_item_by_name(session, item_name):
 
 
 async def ensure_player_by_name_then_auth(session, player_name, account_hash, auth_key):
-    player = None
-    if player_name:
-        player = session.query(Player).filter(Player.player_name.ilike(player_name)).first()
-        if player and player.player_name != player_name:
-            if player.account_hash == account_hash:
-                player.player_name = player_name
-                session.commit()
-    if not player:
-        player = await create_player(player_name, account_hash, existing_session=session)
-        if not player:
-            return None, False, False
-    player_list[player_name] = player.player_id
-    user_exists, authed = check_auth(player_name, account_hash, auth_key, session)
-    return player, authed, user_exists
+    # Use the canonical identity flow so WOM stays source-of-truth for RSN -> WOM ID.
+    return await ensure_player_and_auth(session, player_name, account_hash, auth_key)
 
 
 stored_notifications = {}
@@ -752,70 +811,93 @@ async def create_notification(notification_type, player_id, data, group_id=None,
 
 
 async def create_player(player_name, account_hash, existing_session=None):
-    """Create a player without Discord-specific functionality."""
+    """Create or reconcile a player using WOM-authoritative identity."""
 
-    print("Called create_player")
     use_existing_session = existing_session is not None
     if use_existing_session:
         db_session = existing_session
     else:
         db_session = session
-    account_hash = str(account_hash)
+
+    account_hash = str(account_hash) if account_hash is not None else ""
     if not account_hash or len(account_hash) < 5:
         debug_print("Account hash is too short, aborting")
         return False
-    print("Checking if player exists again...")
-    player = db_session.query(Player).filter(Player.player_name == player_name).first()
 
+    player_name = str(player_name).strip() if player_name is not None else ""
+    if not player_name:
+        return None
+
+    # Always resolve via WOM first so RSN -> WOM ID is authoritative.
+    wom_player, resolved_name, wom_player_id, log_slots = await get_wom_user_cached(player_name)
+    if not wom_player or wom_player_id in (None, "", 0):
+        debug_print(f"WOM lookup failed for {player_name}; refusing non-authoritative create")
+        return None
+
+    try:
+        expected_wom_id = int(wom_player_id)
+    except (TypeError, ValueError):
+        return None
+
+    canonical_name = str(resolved_name or player_name)
+    wom_total_level = _extract_total_level_from_wom_player(wom_player)
+    player = db_session.query(Player).filter(Player.wom_id == expected_wom_id).first()
     if not player:
-        wom_player, player_name, wom_player_id, log_slots = await get_wom_user_cached(player_name)
-        account_hash = str(account_hash)
-        print("Returned from wom check...")
+        # Fallback to existing local identity rows and reconcile to authoritative WOM ID.
+        player = db_session.query(Player).filter(Player.account_hash == account_hash).first()
+    if not player:
+        player = db_session.query(Player).filter(Player.player_name == player_name).first()
 
-        if not wom_player:
-            print("No wom player found.")
-            return None
-
-        player = db_session.query(Player).filter(Player.wom_id == wom_player_id).first()
-        if not player:
-            player = db_session.query(Player).filter(Player.account_hash == account_hash).first()
-
-        if player is not None:
-            # Update existing player with new account hash if needed
-            if player.account_hash != account_hash:
-                player.account_hash = account_hash
-                player.log_slots = log_slots
+    if player is not None:
+        old_name = player.player_name
+        player, changed = _apply_authoritative_wom_identity(
+            db_session,
+            player,
+            expected_wom_id,
+            canonical_name=canonical_name,
+            total_level=wom_total_level,
+            log_slots=log_slots,
+            account_hash=account_hash,
+        )
+        if changed:
+            try:
                 db_session.commit()
-                debug_print(f"Updated existing player {player_name} with new account hash")
-            if normalize_player_display_equivalence(player_name) != normalize_player_display_equivalence(player.player_name):
-                old_name = player.player_name
-                player.player_name = player_name
-                player.log_slots = log_slots
-                db_session.commit()
+            except Exception as e:
+                db_session.rollback()
+                debug_print("Error committing reconciled player row: " + str(e))
+                return None
 
-                notification_data = {"player_name": player_name, "player_id": player.player_id, "old_name": old_name}
-                if player:
-                    if player.user:
-                        user = db_session.query(User).filter(User.user_id == player.user_id).first()
-                        if user:
-                            should_dm_cfg = (
-                                db_session.query(UserConfiguration)
-                                .filter(
-                                    UserConfiguration.user_id == user.user_id,
-                                    UserConfiguration.config_key == "dm_account_changes",
-                                )
-                                .first()
+            if (
+                old_name
+                and normalize_player_display_equivalence(old_name)
+                != normalize_player_display_equivalence(player.player_name)
+            ):
+                notification_data = {
+                    "player_name": player.player_name,
+                    "player_id": player.player_id,
+                    "old_name": old_name,
+                }
+                if player.user:
+                    user = db_session.query(User).filter(User.user_id == player.user_id).first()
+                    if user:
+                        should_dm_cfg = (
+                            db_session.query(UserConfiguration)
+                            .filter(
+                                UserConfiguration.user_id == user.user_id,
+                                UserConfiguration.config_key == "dm_account_changes",
                             )
-                            if should_dm_cfg:
-                                should_dm = str(should_dm_cfg.config_value).lower()
-                                should_dm = True if should_dm in ("true", "1") else False
-                                if should_dm:
-                                    await create_notification(
-                                        "dm_name_change",
-                                        player.player_id,
-                                        notification_data,
-                                        existing_session=db_session if use_existing_session else None,
-                                    )
+                            .first()
+                        )
+                        if should_dm_cfg:
+                            should_dm = str(should_dm_cfg.config_value).lower()
+                            should_dm = True if should_dm in ("true", "1") else False
+                            if should_dm:
+                                await create_notification(
+                                    "dm_name_change",
+                                    player.player_id,
+                                    notification_data,
+                                    existing_session=db_session if use_existing_session else None,
+                                )
 
                 await create_notification(
                     "name_change",
@@ -823,36 +905,39 @@ async def create_player(player_name, account_hash, existing_session=None):
                     notification_data,
                     existing_session=db_session if use_existing_session else None,
                 )
-        else:
-            # Only create new player if no existing player found
-            debug_print(f"Creating new player for {player_name}")
-            try:
-                overall = wom_player.latest_snapshot.data.skills.get("overall")
-                total_level = overall.level
-            except Exception:
-                total_level = 0
+    else:
+        try:
+            overall = wom_player.latest_snapshot.data.skills.get("overall")
+            total_level = overall.level
+        except Exception:
+            total_level = 0
 
-            new_player = Player(
-                wom_id=wom_player_id,
-                player_name=player_name,
-                account_hash=account_hash,
-                total_level=total_level,
-                log_slots=log_slots,
-            )
-            db_session.add(new_player)
+        new_player = Player(
+            wom_id=expected_wom_id,
+            player_name=canonical_name,
+            account_hash=account_hash,
+            total_level=total_level,
+            log_slots=log_slots if log_slots is not None else 0,
+        )
+        db_session.add(new_player)
+        try:
             db_session.commit()
-
-            player_list[player_name] = new_player.player_id
+        except Exception:
+            db_session.rollback()
+            player = db_session.query(Player).filter(Player.wom_id == expected_wom_id).first()
+            if not player:
+                return None
+        else:
+            player = new_player
             app_logger.log(
                 log_type="access",
-                data=f"{player_name} has been created with ID {new_player.player_id} (hash: {account_hash}) ",
+                data=f"{canonical_name} has been created with ID {new_player.player_id} (hash: {account_hash}) ",
                 app_name="core",
                 description="create_player",
             )
-
             notification_data = {
-                "player_name": player_name,
-                "wom_id": wom_player_id,
+                "player_name": canonical_name,
+                "wom_id": expected_wom_id,
                 "player_id": new_player.player_id,
                 "account_hash": account_hash,
             }
@@ -863,15 +948,9 @@ async def create_player(player_name, account_hash, existing_session=None):
                 existing_session=db_session if use_existing_session else None,
             )
 
-            return new_player
-    else:
-        # Player exists by name, update account hash if needed
-        if player.account_hash != account_hash:
-            player.account_hash = account_hash
-            db_session.commit()
-            debug_print(f"Updated existing player {player_name} with new account hash")
-        player_list[player_name] = player.player_id
-
+    player_list[player_name] = player.player_id
+    if canonical_name:
+        player_list[canonical_name] = player.player_id
     return player
 
 
@@ -879,82 +958,44 @@ async def try_create_player(bot: interactions.Client, player_name, account_hash)
     account_hash = str(account_hash)
     if not account_hash or len(account_hash) < 5:
         return False
-    player = session.query(Player).filter(Player.player_name == player_name).first()
-
+    resolved_name = str(player_name).strip() if player_name is not None else ""
+    player = await create_player(resolved_name, account_hash, existing_session=session)
     if not player:
-        print("Player not found in database, checking WOM...")
-        wom_player, player_name, wom_player_id, log_slots = await get_wom_user_cached(player_name)
-        account_hash = str(account_hash)
-        if not wom_player:
-            print("WOM player doesn't exist, and we can't update them/create them:", {player_name})
-        elif not wom_player.latest_snapshot:
-            print(f"Failed to find or create player via WOM: {player_name}. Aborting.")
-            return
-        player = session.query(Player).filter(Player.wom_id == wom_player_id).first()
-        if not player:
-            print("Player not found in database, checking account hash...")
-            player = session.query(Player).filter(Player.account_hash == account_hash).first()
-        if player is not None:
-            if normalize_player_display_equivalence(player_name) != normalize_player_display_equivalence(player.player_name):
-                old_name = player.player_name
-                player.player_name = player_name
-                player.log_slots = log_slots
-                session.commit()
-                if player.user:
-                    user: User = player.user
-                    user_discord_id = user.discord_id
-                    if user_discord_id:
-                        try:
-                            user = await bot.fetch_user(user_id=user_discord_id)
-                            if user:
-                                embed = interactions.Embed(
-                                    title=f"Name change detected:",
-                                    description=f"Your account, {old_name}, has changed names to {player_name}.",
-                                    color="#00f0f0",
-                                )
-                                embed.add_field(
-                                    name=f"Is this a mistake?",
-                                    value=f"Reach out in [our discord](https://www.droptracker.io/discord)",
-                                )
-                                embed.set_footer(global_footer)
-                                await user.send(f"Hey, <@{user.discord_id}>", embed=embed)
-                        except Exception as e:
-                            debug_print("Couldn't DM the user on a name change:" + str(e))
-                from utils.messages import name_change_message
+        return None
 
-                await name_change_message(bot, player_name, player.player_id, old_name)
-        else:
-            debug_print("Player not found in database, creating new player..." + str(e))
-            try:
-                overall = wom_player.latest_snapshot.data.skills.get("overall")
-                total_level = overall.level
-            except Exception:
-                total_level = 0
-            new_player = Player(
-                wom_id=wom_player_id,
-                player_name=player_name,
-                account_hash=account_hash,
-                total_level=total_level,
-                log_slots=log_slots,
-            )
-            session.add(new_player)
-            from utils.messages import new_player_message
+    normalized_old = normalize_player_display_equivalence(resolved_name)
+    normalized_new = normalize_player_display_equivalence(player.player_name or "")
+    if normalized_old and normalized_new and normalized_old != normalized_new:
+        old_name = resolved_name
+        new_name = player.player_name
+        if player.user:
+            user: User = player.user
+            user_discord_id = user.discord_id
+            if user_discord_id:
+                try:
+                    user = await bot.fetch_user(user_id=user_discord_id)
+                    if user:
+                        embed = interactions.Embed(
+                            title="Name change detected:",
+                            description=f"Your account, {old_name}, has changed names to {new_name}.",
+                            color="#00f0f0",
+                        )
+                        embed.add_field(
+                            name="Is this a mistake?",
+                            value="Reach out in [our discord](https://www.droptracker.io/discord)",
+                        )
+                        embed.set_footer(global_footer)
+                        await user.send(f"Hey, <@{user.discord_id}>", embed=embed)
+                except Exception as e:
+                    debug_print("Couldn't DM the user on a name change:" + str(e))
+        from utils.messages import name_change_message
 
-            await new_player_message(bot, player_name)
-            session.commit()
-            player_list[player_name] = new_player.player_id
-            app_logger.log(
-                log_type="access",
-                data=f"{player_name} has been created with ID {new_player.player_id} (hash: {account_hash}) ",
-                app_name="core",
-                description="try_create_player",
-            )
-            return new_player
-    else:
-        stored_account_hash = player.account_hash
-        if str(stored_account_hash) != account_hash:
-            debug_print("Potential fake submission from " + player_name + " with a changed account hash!!")
-        player_list[player_name] = player.player_id
+        await name_change_message(bot, new_name, player.player_id, old_name)
+
+    player_list[resolved_name] = player.player_id
+    if player.player_name:
+        player_list[player.player_name] = player.player_id
+    return player
 
 
 async def log_to_file(data):

--- a/db/ops.py
+++ b/db/ops.py
@@ -414,62 +414,84 @@ class DatabaseOperations:
             It also creates a new player notification entry.    
         """
         account_hash = str(account_hash)
-        
+
         try:
-            # Check if player exists in WiseOldMan
-            wom_player, player_name, wom_player_id, log_slots = await check_user_by_username(player_name)
-            
-            if not wom_player or not wom_player.latest_snapshot:
+            # WOM is authoritative for RSN -> WOM ID; always resolve identity via WOM first.
+            wom_player, resolved_name, wom_player_id, log_slots = await check_user_by_username(player_name)
+
+            if not wom_player or wom_player_id in (None, "", 0):
                 return None
-            
-            player = session.query(Player).filter(Player.wom_id == wom_player_id).first()
+
+            try:
+                expected_wom_id = int(wom_player_id)
+            except (TypeError, ValueError):
+                return None
+
+            canonical_name = str(resolved_name or player_name)
+            player = session.query(Player).filter(Player.wom_id == expected_wom_id).first()
             if not player:
+                # Legacy fallback rows can still exist by hash/name; reconcile those.
                 player = session.query(Player).filter(Player.account_hash == account_hash).first()
-            
+            if not player:
+                player = session.query(Player).filter(Player.player_name == player_name).first()
+
             if player is not None:
-                if normalize_player_display_equivalence(player_name) != normalize_player_display_equivalence(player.player_name):
-                    old_name = player.player_name
-                    player.player_name = player_name
-                    player.log_slots = log_slots
+                changed = False
+                old_name = player.player_name
+                if int(player.wom_id or 0) != expected_wom_id:
+                    player.wom_id = expected_wom_id
+                    changed = True
+                if normalize_player_display_equivalence(canonical_name) != normalize_player_display_equivalence(player.player_name):
+                    player.player_name = canonical_name
+                    changed = True
+                if log_slots is not None and int(log_slots) >= 0 and int(player.log_slots or 0) != int(log_slots):
+                    player.log_slots = int(log_slots)
+                    changed = True
+                if account_hash and not player.account_hash:
+                    player.account_hash = account_hash
+                    changed = True
+                if changed:
                     session.commit()
-                    
-                    # Create name change notification
-                    notification_data = {
-                        'player_name': player_name,
-                        'player_id': player.player_id,
-                        'old_name': old_name
-                    }
-                    await self.create_notification('name_change', player.player_id, notification_data)
+                    if old_name and normalize_player_display_equivalence(old_name) != normalize_player_display_equivalence(player.player_name):
+                        notification_data = {
+                            "player_name": player.player_name,
+                            "player_id": player.player_id,
+                            "old_name": old_name,
+                        }
+                        await self.create_notification("name_change", player.player_id, notification_data)
             else:
                 try:
-                    overall = wom_player.latest_snapshot.data.skills.get('overall')
+                    overall = wom_player.latest_snapshot.data.skills.get("overall")
                     total_level = overall.level
-                except Exception as e:
+                except Exception:
                     total_level = 0
-                
+
                 new_player = Player(
-                    wom_id=wom_player_id, 
-                    player_name=player_name, 
-                    account_hash=account_hash, 
+                    wom_id=expected_wom_id,
+                    player_name=canonical_name,
+                    account_hash=account_hash,
                     total_level=total_level,
-                    log_slots=log_slots
+                    log_slots=log_slots if log_slots is not None else 0,
                 )
                 session.add(new_player)
                 session.commit()
-                
-                app_logger.log(log_type="access", data=f"{player_name} has been created with ID {new_player.player_id} (hash: {account_hash}) ", app_name="core", description="create_player")
-                
+
+                app_logger.log(
+                    log_type="access",
+                    data=f"{canonical_name} has been created with ID {new_player.player_id} (hash: {account_hash}) ",
+                    app_name="core",
+                    description="create_player",
+                )
+
                 # Create new player notification
-                notification_data = {
-                    'player_name': player_name
-                }
-                await self.create_notification('new_player', new_player.player_id, notification_data)
-                
+                notification_data = {"player_name": canonical_name}
+                await self.create_notification("new_player", new_player.player_id, notification_data)
+
                 return new_player
         except Exception as e:
             app_logger.log(log_type="error", data=f"Error creating player: {e}", app_name="core", description="create_player")
             return None
-        
+
         return player
     
     async def process_drop(self, drop_data, message_id=None, message_logger=None):

--- a/scripts/diagnose_group_membership.py
+++ b/scripts/diagnose_group_membership.py
@@ -38,6 +38,31 @@ def _hr(title: str = ""):
     print("\n" + ("─" * 60) + (f"  {title}" if title else ""))
 
 
+def _extract_group_metadata(details):
+    """
+    Support multiple wom.py response shapes.
+
+    Some versions expose group metadata directly on the details object
+    (`details.name`, `details.member_count`) while others nest it under
+    `details.group`.
+    """
+    nested_group = getattr(details, "group", None)
+    wom_name = getattr(nested_group, "name", None)
+    member_count = getattr(nested_group, "member_count", None)
+
+    if wom_name is None:
+        wom_name = getattr(details, "name", None)
+    if member_count is None:
+        member_count = getattr(details, "member_count", None)
+
+    try:
+        member_count = int(member_count) if member_count is not None else None
+    except (TypeError, ValueError):
+        member_count = None
+
+    return wom_name, member_count
+
+
 def _check_db(player_name: str, wom_group_id: int):
     _hr("DB: player record")
     player = db_session.query(Player).filter(Player.player_name == player_name).first()
@@ -88,53 +113,53 @@ async def _check_wom(wom_group_id: int, player_wom_id: int | None):
     WOM_API_KEY = os.getenv("WOM_API_KEY")
     client = wom_lib.Client(WOM_API_KEY, user_agent="@joelhalen-diagnostic")
     await client.start()
-
-    _hr("WOM API: raw group details")
-    result = await client.groups.get_details(wom_group_id)
-    if not result.is_ok:
-        print(f"  [ERROR] WOM API call failed: {result}")
-        await client.close()
-        return None, None
-
-    details = result.unwrap()
-    wom_members = details.memberships
     try:
-        reported_count = details.group.member_count
-    except AttributeError:
-        reported_count = None
-    wom_name = details.group.name
+        _hr("WOM API: raw group details")
+        result = await client.groups.get_details(wom_group_id)
+        if not result.is_ok:
+            print(f"  [ERROR] WOM API call failed: {result}")
+            return None, None
 
-    print(f"  Group name     : {wom_name}")
-    print(f"  member_count   : {reported_count}  (as reported by the API response)")
-    print(f"  Memberships len: {len(wom_members)}  (actual items in memberships list)")
+        details = result.unwrap()
+        wom_members = details.memberships
+        wom_name, reported_count = _extract_group_metadata(details)
 
-    if reported_count is not None and len(wom_members) < reported_count:
-        print(
-            f"\n  *** INCOMPLETE RESPONSE DETECTED ***\n"
-            f"  WOM returned {len(wom_members)} member records but claims {reported_count} members.\n"
-            f"  The skip_removals guard introduced in this fix would prevent erroneous removals."
-        )
-    elif reported_count is not None:
-        print(f"\n  Response looks complete ({len(wom_members)} == {reported_count}).")
+        print(f"  Group name     : {wom_name}")
+        print(f"  member_count   : {reported_count}  (as reported by the API response)")
+        print(f"  Memberships len: {len(wom_members)}  (actual items in memberships list)")
 
-    wom_ids = {m.player_id for m in wom_members}
+        if reported_count is not None and len(wom_members) < reported_count:
+            print(
+                f"\n  *** INCOMPLETE RESPONSE DETECTED ***\n"
+                f"  WOM returned {len(wom_members)} member records but claims {reported_count} members.\n"
+                f"  The skip_removals guard introduced in this fix would prevent erroneous removals."
+            )
+        elif reported_count is not None:
+            print(f"\n  Response looks complete ({len(wom_members)} == {reported_count}).")
 
-    _hr("WOM API: target player membership check")
-    if player_wom_id is not None:
-        if player_wom_id in wom_ids:
-            print(f"  [PRESENT]  wom_id {player_wom_id} IS in the WOM member list.")
+        wom_ids = {m.player_id for m in wom_members}
+
+        _hr("WOM API: target player membership check")
+        if player_wom_id is not None:
+            if player_wom_id in wom_ids:
+                print(f"  [PRESENT]  wom_id {player_wom_id} IS in the WOM member list.")
+            else:
+                print(f"  [ABSENT]   wom_id {player_wom_id} is NOT in the WOM member list.")
+                # Try to find the player by name
+                for m in wom_members:
+                    m_player = getattr(m, "player", None)
+                    display_name = getattr(m_player, "display_name", None)
+                    if display_name and "kerzington" in display_name.lower():
+                        print(
+                            "  HINT: found a member whose name contains the target string: "
+                            f"id={m.player_id}  name={display_name}"
+                        )
         else:
-            print(f"  [ABSENT]   wom_id {player_wom_id} is NOT in the WOM member list.")
-            # Try to find the player by name
-            for m in wom_members:
-                if m.player and m.player.display_name and "kerzington" in m.player.display_name.lower():
-                    print(f"  HINT: found a member whose name contains the target string: "
-                          f"id={m.player_id}  name={m.player.display_name}")
-    else:
-        print("  Cannot check: player has no wom_id in the DB.")
+            print("  Cannot check: player has no wom_id in the DB.")
 
-    await client.close()
-    return wom_ids, wom_members
+        return wom_ids, wom_members
+    finally:
+        await client.close()
 
 
 def _dry_run_sync(player: Player, group: Group, wom_ids: set, wom_members):

--- a/utils/wiseoldman.py
+++ b/utils/wiseoldman.py
@@ -54,6 +54,31 @@ _group_member_count: Dict[int, int] = {}
 _player_cache_lock = asyncio.Lock()
 _group_cache_lock = asyncio.Lock()
 
+
+def _extract_group_metadata(details: Any) -> Tuple[Optional[str], Optional[int]]:
+    """
+    Normalize group metadata across WOM response shapes.
+
+    Depending on wom.py version, group details may be exposed either directly on the
+    returned object (`details.name`, `details.member_count`) or nested under a
+    `details.group` object (`details.group.name`, `details.group.member_count`).
+    """
+    nested_group = getattr(details, "group", None)
+    group_name = getattr(nested_group, "name", None)
+    member_count = getattr(nested_group, "member_count", None)
+
+    if group_name is None:
+        group_name = getattr(details, "name", None)
+    if member_count is None:
+        member_count = getattr(details, "member_count", None)
+
+    try:
+        member_count = int(member_count) if member_count is not None else None
+    except (TypeError, ValueError):
+        member_count = None
+
+    return group_name, member_count
+
 async def _get_cached_player(username: str, force_refresh: bool) -> Optional[Tuple[Any, float]]:
     normalized = username.strip().lower()
     now = _now()
@@ -245,8 +270,7 @@ async def check_group_by_id(wom_group_id: int, *, force_refresh: bool = False):
         if result.is_ok:
             details = result.unwrap()
             members = details.memberships
-            member_count = details.group.member_count
-            group_name = details.group.name
+            group_name, member_count = _extract_group_metadata(details)
             member_ids = [member.player_id for member in members]
             await _store_group_cache(wom_group_id, member_ids)
             return group_name, member_count, members
@@ -318,16 +342,14 @@ async def fetch_group_members(
             members = details.memberships
             # Store the WOM-reported expected member count so _sync_group_from_wom
             # can detect and refuse to act on incomplete API responses.
-            try:
-                wom_expected_count = details.group.member_count
-            except AttributeError:
-                wom_expected_count = None
+            group_name, wom_expected_count = _extract_group_metadata(details)
             if wom_expected_count is not None:
-                _group_member_count[wom_group_id] = int(wom_expected_count)
-            name = details.name
+                _group_member_count[wom_group_id] = wom_expected_count
+            name = group_name
             #print(f"Group name: {name}")
             for member in members:
-                player_name = member.player.display_name
+                player_obj = getattr(member, "player", None)
+                player_name = getattr(player_obj, "display_name", None)
                 member_wom_id = member.player_id
                 existing_player = session.query(Player).filter(Player.wom_id == member_wom_id).first()
                 if existing_player:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- normalize WOM group metadata extraction to support both response shapes:
  - nested (`details.group.name`, `details.group.member_count`)
  - flat (`details.name`, `details.member_count`)
- fix diagnostic script stability and cleanup:
  - schema-tolerant metadata access
  - guaranteed client close via `try/finally`
  - safe handling for missing nested player objects
- enforce WOM as source-of-truth for player identity (`RSN -> WOM ID`):
  - canonicalize player resolution in submission/auth flows
  - reconcile stale local rows to WOM IDs when available
  - route `ensure_player_by_name_then_auth` through canonical flow
  - make `create_player` reconciliation WOM-authoritative
  - update `/claim-rsn` to resolve by WOM ID first and correct stale local WOM IDs

## Why
Issue #9 and follow-up diagnostics indicated stale local WOM IDs can persist and then trigger incorrect membership removals. The fix ensures every key identity path reconciles local player records against live WOM identity before trust/association decisions are made.

## Validation
- `python3 -m py_compile commands.py data/submissions/common.py db/ops.py utils/wiseoldman.py scripts/diagnose_group_membership.py`

## Files changed
- `utils/wiseoldman.py`
- `scripts/diagnose_group_membership.py`
- `data/submissions/common.py`
- `db/ops.py`
- `commands.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa0bd4e0-47f4-42fb-8041-fd909c6e5a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa0bd4e0-47f4-42fb-8041-fd909c6e5a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

