### PR TITLE

fix: correct GroupDetail attribute access (details.member_count, details.name)


### DIFF
--- a/scripts/diagnose_group_membership.py
+++ b/scripts/diagnose_group_membership.py
@@ -84,57 +84,55 @@ def _check_db(player_name: str, wom_group_id: int):
     return player, group
 
 
-async def _check_wom(wom_group_id: int, player_wom_id: int | None):
+async def _check_wom(wom_group_id: int, player_wom_id: int | None, player_name: str = ""):
     WOM_API_KEY = os.getenv("WOM_API_KEY")
     client = wom_lib.Client(WOM_API_KEY, user_agent="@joelhalen-diagnostic")
     await client.start()
 
-    _hr("WOM API: raw group details")
-    result = await client.groups.get_details(wom_group_id)
-    if not result.is_ok:
-        print(f"  [ERROR] WOM API call failed: {result}")
-        await client.close()
-        return None, None
-
-    details = result.unwrap()
-    wom_members = details.memberships
     try:
-        reported_count = details.group.member_count
-    except AttributeError:
-        reported_count = None
-    wom_name = details.group.name
+        _hr("WOM API: raw group details")
+        result = await client.groups.get_details(wom_group_id)
+        if not result.is_ok:
+            print(f"  [ERROR] WOM API call failed: {result}")
+            return None, None
 
-    print(f"  Group name     : {wom_name}")
-    print(f"  member_count   : {reported_count}  (as reported by the API response)")
-    print(f"  Memberships len: {len(wom_members)}  (actual items in memberships list)")
+        details = result.unwrap()
+        wom_members = details.memberships
+        reported_count = getattr(details, "member_count", None)
+        wom_name = details.name
 
-    if reported_count is not None and len(wom_members) < reported_count:
-        print(
-            f"\n  *** INCOMPLETE RESPONSE DETECTED ***\n"
-            f"  WOM returned {len(wom_members)} member records but claims {reported_count} members.\n"
-            f"  The skip_removals guard introduced in this fix would prevent erroneous removals."
-        )
-    elif reported_count is not None:
-        print(f"\n  Response looks complete ({len(wom_members)} == {reported_count}).")
+        print(f"  Group name     : {wom_name}")
+        print(f"  member_count   : {reported_count}  (as reported by the API response)")
+        print(f"  Memberships len: {len(wom_members)}  (actual items in memberships list)")
 
-    wom_ids = {m.player_id for m in wom_members}
+        if reported_count is not None and len(wom_members) < reported_count:
+            print(
+                f"\n  *** INCOMPLETE RESPONSE DETECTED ***\n"
+                f"  WOM returned {len(wom_members)} member records but claims {reported_count} members.\n"
+                f"  The skip_removals guard introduced in this fix would prevent erroneous removals."
+            )
+        elif reported_count is not None:
+            print(f"\n  Response looks complete ({len(wom_members)} == {reported_count}).")
 
-    _hr("WOM API: target player membership check")
-    if player_wom_id is not None:
-        if player_wom_id in wom_ids:
-            print(f"  [PRESENT]  wom_id {player_wom_id} IS in the WOM member list.")
+        wom_ids = {m.player_id for m in wom_members}
+
+        _hr("WOM API: target player membership check")
+        target_name = player_name
+        if player_wom_id is not None:
+            if player_wom_id in wom_ids:
+                print(f"  [PRESENT]  wom_id {player_wom_id} IS in the WOM member list.")
+            else:
+                print(f"  [ABSENT]   wom_id {player_wom_id} is NOT in the WOM member list.")
+                for m in wom_members:
+                    if m.player and m.player.display_name and target_name.lower() in m.player.display_name.lower():
+                        print(f"  HINT: found a member whose name contains the target string: "
+                              f"id={m.player_id}  name={m.player.display_name}")
         else:
-            print(f"  [ABSENT]   wom_id {player_wom_id} is NOT in the WOM member list.")
-            # Try to find the player by name
-            for m in wom_members:
-                if m.player and m.player.display_name and "kerzington" in m.player.display_name.lower():
-                    print(f"  HINT: found a member whose name contains the target string: "
-                          f"id={m.player_id}  name={m.player.display_name}")
-    else:
-        print("  Cannot check: player has no wom_id in the DB.")
+            print("  Cannot check: player has no wom_id in the DB.")
 
-    await client.close()
-    return wom_ids, wom_members
+        return wom_ids, wom_members
+    finally:
+        await client.close()
 
 
 def _dry_run_sync(player: Player, group: Group, wom_ids: set, wom_members):
@@ -201,7 +199,7 @@ async def main():
     player, group = _check_db(player_name, wom_group_id)
     player_wom_id = player.wom_id if player else None
 
-    wom_ids, wom_members = await _check_wom(wom_group_id, player_wom_id)
+    wom_ids, wom_members = await _check_wom(wom_group_id, player_wom_id, player_name)
 
     if group is not None and wom_ids is not None:
         _dry_run_sync(player, group, wom_ids, wom_members)

--- a/utils/wiseoldman.py
+++ b/utils/wiseoldman.py
@@ -245,8 +245,8 @@ async def check_group_by_id(wom_group_id: int, *, force_refresh: bool = False):
         if result.is_ok:
             details = result.unwrap()
             members = details.memberships
-            member_count = details.group.member_count
-            group_name = details.group.name
+            member_count = details.member_count
+            group_name = details.name
             member_ids = [member.player_id for member in members]
             await _store_group_cache(wom_group_id, member_ids)
             return group_name, member_count, members
@@ -318,10 +318,7 @@ async def fetch_group_members(
             members = details.memberships
             # Store the WOM-reported expected member count so _sync_group_from_wom
             # can detect and refuse to act on incomplete API responses.
-            try:
-                wom_expected_count = details.group.member_count
-            except AttributeError:
-                wom_expected_count = None
+            wom_expected_count = getattr(details, "member_count", None)
             if wom_expected_count is not None:
                 _group_member_count[wom_group_id] = int(wom_expected_count)
             name = details.name


### PR DESCRIPTION

The wom.py GroupDetail object exposes .name and .member_count directly; there
is no intermediate .group sub-object.  The previous code used details.group.*
in two places:

- check_group_by_id: details.group.member_count / details.group.name now
  corrected to details.member_count / details.name.
- fetch_group_members: the try/except around details.group.member_count was
  silently swallowing AttributeError, so _group_member_count was never
  populated and the skip_removals safety check from the prior commit was
  effectively dead.  Replaced with getattr(details, "member_count", None).

Also fixes the diagnostic script (scripts/diagnose_group_membership.py):
- Same attribute correction (details.name, getattr member_count).
- Pass player_name into _check_wom as an explicit parameter instead of
  referencing it as an unbound outer-scope variable (would have raised
  NameError at runtime).
- Wrap the WOM API calls in try/finally so the aiohttp client session is
  always closed even if an exception is raised mid-flight.

