### PR TITLE
Add /sync-wom Discord command, WOM sync API endpoint, and 1-hour cooldown

### DIFF
--- a/api/routes/groups.py
+++ b/api/routes/groups.py
@@ -17,7 +17,7 @@ from services.redis_updates import get_player_list_loot_sum
 from utils.format import format_number
 from utils.wiseoldman import fetch_group_members
 from db import Player, Group, GroupConfiguration, NotifiedSubmission, NpcList, get_current_partition
-from db.ops import associate_player_ids
+from db.ops import associate_player_ids, sync_group_from_wom_with_stats
 from utils.redis import calculate_rank_amongst_groups
 
 
@@ -524,4 +524,112 @@ async def generate_timeframe_board_endpoint():
     except Exception as e:
         print(f"[TimeframeBoardAPI] Unexpected error: {e}")
         return jsonify({"success": False, "error": str(e)}), 500
+
+
+# ==============================================================================
+# WOM SYNC ENDPOINT
+# ==============================================================================
+# Trigger an on-demand WOM membership sync for a group, identical to what the
+# /sync-wom Discord command performs.  Intended for the website's "Sync" button.
+#
+# AUTHENTICATION
+#   Pass the group's export API key (GroupConfiguration key = "export_api_key")
+#   as either:
+#     • JSON body field: { "api_key": "<key>", ... }
+#     • Authorization header: Bearer <key>
+#
+# REQUEST FORMAT (POST /groups/<group_id>/wom-sync):
+#   { "group_id": int }   — group_id in the URL path is sufficient; body is optional.
+#
+# RESPONSE FORMAT:
+#   Success (200): {
+#     "success": true,
+#     "group_name": str,
+#     "group_id": int,
+#     "wom_id": int,
+#     "added": [str, ...],
+#     "removed": [str, ...],
+#     "total_members": int,
+#     "skipped_removals": bool,
+#     "duration_seconds": float
+#   }
+#   Cooldown (429): {
+#     "success": false,
+#     "on_cooldown": true,
+#     "cooldown_remaining_seconds": int,
+#     "group_name": str
+#   }
+#   Auth failure (401/403): { "success": false, "error": str }
+#   Not found    (404):      { "success": false, "error": str }
+# ==============================================================================
+
+@groups_bp.post("/groups/<int:group_id>/wom-sync")
+@route_cors(allow_origin="https://www.droptracker.io")
+@rate_limit(limit=10, period=timedelta(seconds=60))
+async def group_wom_sync(group_id: int):
+    """Trigger an on-demand WOM membership sync for the given group."""
+    db_session = get_db_session()
+    try:
+        # --- Resolve group ---
+        group = db_session.query(Group).filter(Group.group_id == group_id).first()
+        if not group:
+            return jsonify({"success": False, "error": f"Group {group_id} not found"}), 404
+
+        if not group.wom_id:
+            return jsonify({"success": False, "error": "This group has no WOM ID configured"}), 400
+
+        # --- Authenticate ---
+        # Accept the key from either the Authorization header or the JSON body.
+        api_key = None
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.lower().startswith("bearer "):
+            api_key = auth_header[7:].strip()
+
+        if not api_key:
+            try:
+                body = await request.get_json(silent=True) or {}
+                api_key = body.get("api_key", "")
+            except Exception:
+                api_key = ""
+
+        if not api_key:
+            return jsonify({"success": False, "error": "API key required"}), 401
+
+        key_cfg = db_session.query(GroupConfiguration).filter(
+            GroupConfiguration.group_id == group_id,
+            GroupConfiguration.config_key == "export_api_key",
+        ).first()
+
+        if not key_cfg or str(key_cfg.config_value).strip() != str(api_key).strip():
+            return jsonify({"success": False, "error": "Invalid API key"}), 403
+
+        # --- Perform sync ---
+        try:
+            result = await sync_group_from_wom_with_stats(wom_id=int(group.wom_id))
+        except Exception as e:
+            print(f"[WomSyncAPI] Sync error for group {group_id}: {e}")
+            return jsonify({"success": False, "error": str(e)}), 500
+
+        if result["on_cooldown"]:
+            return jsonify({
+                "success": False,
+                "on_cooldown": True,
+                "cooldown_remaining_seconds": result["cooldown_remaining_seconds"],
+                "group_name": result["group_name"],
+            }), 429
+
+        return jsonify({
+            "success": True,
+            "group_name": result["group_name"],
+            "group_id": result["group_id"],
+            "wom_id": result["wom_id"],
+            "added": result["added"],
+            "removed": result["removed"],
+            "total_members": result["total_members"],
+            "skipped_removals": result["skipped_removals"],
+            "duration_seconds": result["duration_seconds"],
+        }), 200
+
+    finally:
+        db_session.close()
 

--- a/commands/user.py
+++ b/commands/user.py
@@ -20,7 +20,7 @@ from services.components import help_components
 from services.points import award_points_to_player
 from utils.format import format_time_since_update, get_command_id, get_player_by_claim_rsn
 from utils.wiseoldman import check_user_by_username
-from .utils import try_create_user
+from .utils import try_create_user, is_admin, is_user_authorized
 from sqlalchemy import func
 
 
@@ -715,4 +715,111 @@ class UserCommands(Extension):
         else:
             embed.add_field(name="Top Players", value="No points have been awarded yet.", inline=False)
 
+        await ctx.send(embed=embed, ephemeral=True)
+
+    @slash_command(
+        name="sync-wom",
+        description="Request an immediate WiseOldMan membership sync for this group (1-hour cooldown)",
+    )
+    async def sync_wom_cmd(self, ctx: SlashContext):
+        """
+        Trigger a WiseOldMan membership sync for the group linked to this Discord server.
+
+        Available to guild administrators and users listed in the group's ``authed_users``
+        configuration.  Enforces a 1-hour per-group cooldown to avoid hammering the WOM API.
+        The response is deferred so the interaction won't time out during a long sync.
+        """
+        self._refresh_session()
+
+        if not ctx.guild_id:
+            return await ctx.send(
+                "This command must be used inside your group's Discord server.",
+                ephemeral=True,
+            )
+
+        guild = session.query(Guild).filter(Guild.guild_id == str(ctx.guild_id)).first()
+        if not guild or not guild.group_id:
+            return await ctx.send(
+                "This Discord server is not linked to a DropTracker group.",
+                ephemeral=True,
+            )
+
+        group = session.query(Group).filter(Group.group_id == guild.group_id).first()
+        if not group or not group.wom_id:
+            return await ctx.send(
+                "The linked group has no WOM ID configured.",
+                ephemeral=True,
+            )
+
+        # Authorization: guild administrator OR listed in the group's authed_users config
+        user = session.query(User).filter(User.discord_id == str(ctx.author.id)).first()
+        if not is_admin(ctx) and not (user and is_user_authorized(user.user_id, group)):
+            return await ctx.send(
+                "You are not authorized to request a WOM sync for this group.",
+                ephemeral=True,
+            )
+
+        await ctx.defer(ephemeral=True)
+
+        try:
+            from db.ops import sync_group_from_wom_with_stats
+            result = await sync_group_from_wom_with_stats(wom_id=int(group.wom_id))
+        except Exception as e:
+            return await ctx.send(f"WOM sync failed: {e}", ephemeral=True)
+
+        if result["on_cooldown"]:
+            remaining = result["cooldown_remaining_seconds"]
+            hours, rem = divmod(remaining, 3600)
+            minutes = rem // 60
+            time_str = f"{hours}h {minutes}m" if hours else f"{minutes}m"
+            embed = Embed(
+                title="Sync on Cooldown",
+                description=(
+                    f"**{group.group_name}** was synced recently.\n"
+                    f"Please wait **{time_str}** before requesting another sync."
+                ),
+                color=0xE67E22,
+            )
+            return await ctx.send(embed=embed, ephemeral=True)
+
+        added = result["added"]
+        removed = result["removed"]
+
+        def _player_list(names, max_shown=15):
+            if not names:
+                return "None"
+            shown = names[:max_shown]
+            extra = len(names) - max_shown
+            text = ", ".join(f"`{n}`" for n in shown)
+            if extra > 0:
+                text += f" *(+{extra} more)*"
+            return text
+
+        embed = Embed(
+            title="WOM Sync Complete",
+            description=f"Membership sync with WiseOldMan finished for **{result['group_name']}**.",
+            color=0x2ECC71,
+        )
+        embed.add_field(name="Total Members", value=str(result["total_members"]), inline=True)
+        embed.add_field(name="Added", value=str(len(added)), inline=True)
+        embed.add_field(name="Removed", value=str(len(removed)), inline=True)
+
+        if added:
+            embed.add_field(name="New Members", value=_player_list(added), inline=False)
+        if removed:
+            embed.add_field(name="Removed Members", value=_player_list(removed), inline=False)
+
+        if result["skipped_removals"]:
+            embed.add_field(
+                name="Warning: Removal Pass Skipped",
+                value=(
+                    "WOM returned an incomplete member list — no members were removed "
+                    "this cycle to prevent incorrectly evicting valid members."
+                ),
+                inline=False,
+            )
+
+        embed.set_footer(
+            text=f"WOM ID: {result['wom_id']} • Duration: {result['duration_seconds']:.1f}s"
+        )
         await ctx.send(embed=embed, ephemeral=True)

--- a/db/ops.py
+++ b/db/ops.py
@@ -736,17 +736,22 @@ async def notify_group(bot: interactions.Client, type: str, group: Group, member
         else:
             print(f"Channel not found for ID: {channel_id}")
 
-async def _sync_group_from_wom(group: Group, wom_id: int, on_add=None, on_remove=None):
+async def _sync_group_from_wom(group: Group, wom_id: int, on_add=None, on_remove=None) -> dict:
     """
     Core logic for syncing a single group's membership from the WOM API.
 
     on_add(member) and on_remove(member) are optional async callbacks
     invoked after a player is added/removed from the group.
+
+    Returns a dict with keys:
+        added (int): number of players added
+        removed (int): number of players removed
+        skipped_removals (bool): True when removal pass was skipped due to incomplete WOM response
     """
     group_wom_ids = await fetch_group_members(wom_id, force_refresh=True)
     if not group_wom_ids:
         print(f"Failed to fetch member list for group {group.group_name} (WOM ID: {wom_id})")
-        return
+        return {"added": 0, "removed": 0, "skipped_removals": False}
 
     # Safety check: if WOM's own reported member_count differs from the number of
     # memberships returned in the same response, the list is incomplete (e.g. due to
@@ -784,6 +789,9 @@ async def _sync_group_from_wom(group: Group, wom_id: int, on_add=None, on_remove
     group_wom_id_set = set(group_wom_ids)
     group_members = session.query(Player).filter(Player.wom_id.in_(group_wom_ids)).all()
 
+    removed_count = 0
+    added_count = 0
+
     # Remove members no longer in the WOM group (skipped when the API returned a
     # partial/incomplete member list — see skip_removals flag above).
     if not skip_removals:
@@ -802,6 +810,7 @@ async def _sync_group_from_wom(group: Group, wom_id: int, on_add=None, on_remove
                     description="sync_group_from_wom",
                 )
                 member.remove_group(group)
+                removed_count += 1
                 if on_remove:
                     await on_remove(member)
 
@@ -813,6 +822,7 @@ async def _sync_group_from_wom(group: Group, wom_id: int, on_add=None, on_remove
                 member.user.add_group(group)
             member.add_group(group)
             member = session.query(Player).filter(Player.player_id == member.player_id).first()
+            added_count += 1
             if on_add:
                 await on_add(member)
 
@@ -830,6 +840,8 @@ async def _sync_group_from_wom(group: Group, wom_id: int, on_add=None, on_remove
             description="sync_group_from_wom",
         )
         session.rollback()
+
+    return {"added": added_count, "removed": removed_count, "skipped_removals": skip_removals}
 
 
 def _sync_global_group():
@@ -992,6 +1004,107 @@ async def update_group_members_silent(forced_id: int = None):
             continue
 
     _sync_global_group()
+
+
+_WOM_SYNC_COOLDOWN_SECONDS = 3600  # 1 hour
+
+
+async def sync_group_from_wom_with_stats(wom_id: int) -> dict:
+    """
+    Sync a single group from WOM and return a detailed result dict.
+
+    Enforces a 1-hour per-group cooldown tracked via GroupConfiguration
+    (key: ``last_wom_sync``).  Callers should check the ``on_cooldown``
+    key before using the rest of the result.
+
+    Returns a dict with keys:
+        on_cooldown (bool): True when the request was rejected due to cooldown.
+        cooldown_remaining_seconds (int): Seconds until the cooldown expires
+            (only present when ``on_cooldown`` is True).
+        group_name (str): Human-readable group name.
+        group_id (int): DropTracker group primary key.
+        wom_id (int): Wise Old Man group ID.
+        added (list[str]): Names of players added during this sync.
+        removed (list[str]): Names of players removed during this sync.
+        total_members (int): Group member count after the sync.
+        skipped_removals (bool): True when the removal pass was skipped
+            because WOM returned an incomplete member list.
+        duration_seconds (float): Wall-clock time taken for the sync.
+    """
+    group: Group = session.query(Group).filter(Group.wom_id == wom_id).first()
+    if not group:
+        raise ValueError(f"No DropTracker group found with WOM ID {wom_id}")
+
+    # --- Cooldown check ---
+    cooldown_cfg = session.query(GroupConfiguration).filter(
+        GroupConfiguration.group_id == group.group_id,
+        GroupConfiguration.config_key == "last_wom_sync",
+    ).first()
+
+    if cooldown_cfg and cooldown_cfg.config_value:
+        try:
+            last_sync = datetime.fromisoformat(cooldown_cfg.config_value)
+            elapsed = (datetime.utcnow() - last_sync).total_seconds()
+            if elapsed < _WOM_SYNC_COOLDOWN_SECONDS:
+                return {
+                    "on_cooldown": True,
+                    "cooldown_remaining_seconds": int(_WOM_SYNC_COOLDOWN_SECONDS - elapsed),
+                    "group_name": group.group_name,
+                    "group_id": group.group_id,
+                    "wom_id": wom_id,
+                }
+        except (ValueError, TypeError):
+            pass  # Malformed timestamp — treat as no cooldown
+
+    # --- Sync ---
+    added_names: list = []
+    removed_names: list = []
+
+    async def _on_add(member):
+        added_names.append(member.player_name)
+
+    async def _on_remove(member):
+        removed_names.append(member.player_name)
+
+    started_at = datetime.utcnow()
+    try:
+        stats = await _sync_group_from_wom(group, wom_id, on_add=_on_add, on_remove=_on_remove)
+        _sync_global_group()
+    except Exception as e:
+        session.rollback()
+        raise
+
+    duration = (datetime.utcnow() - started_at).total_seconds()
+
+    # --- Update cooldown timestamp ---
+    now_iso = datetime.utcnow().isoformat()
+    if cooldown_cfg:
+        cooldown_cfg.config_value = now_iso
+    else:
+        session.add(GroupConfiguration(
+            group_id=group.group_id,
+            config_key="last_wom_sync",
+            config_value=now_iso,
+        ))
+    try:
+        session.commit()
+    except Exception:
+        session.rollback()
+
+    session.refresh(group)
+    total_members = group.get_player_count()
+
+    return {
+        "on_cooldown": False,
+        "group_name": group.group_name,
+        "group_id": group.group_id,
+        "wom_id": wom_id,
+        "added": added_names,
+        "removed": removed_names,
+        "total_members": total_members,
+        "skipped_removals": stats.get("skipped_removals", False),
+        "duration_seconds": round(duration, 2),
+    }
 
 
 async def get_ev_session():


### PR DESCRIPTION
- db/ops.py: _sync_group_from_wom now returns added/removed/skipped_removals
  stats; new sync_group_from_wom_with_stats() public function handles cooldown
  enforcement (1h, tracked via GroupConfiguration key 'last_wom_sync'), collects
  per-player add/remove names via callbacks, and returns a structured result dict.

- commands/user.py: /sync-wom slash command usable in any registered group
  Discord. Accessible to guild admins and authed_users. Defers the interaction
  to avoid timeouts, then sends a rich embed showing added/removed players,
  total member count, duration, and a warning when the removal pass was skipped.
  Returns a cooldown embed (with remaining time) when the limit is active.

- api/routes/groups.py: POST /groups/<group_id>/wom-sync endpoint for the
  website's sync button. Authenticated via the group's export_api_key
  (Authorization: Bearer <key> or JSON body api_key field). Returns the same
  structured sync result as the Discord command; responds with HTTP 429 when
  the 1-hour cooldown is still active.

https://claude.ai/code/session_01B4CaKzLyFrPUbo9Q9FJGjj