### PR TITLE
Handle submission world_type with main default and non-main no-op routing

### DIFF
--- a/api/routes/webhook.py
+++ b/api/routes/webhook.py
@@ -16,11 +16,58 @@ from utils.video_storage import backend_for_video_record, get_public_video_url
 
 
 webhook_bp = Blueprint("webhook", __name__)
+MAIN_WORLD_TYPE = "main"
 
 
 def _drop_request_debug(message: str):
     """Consistent logging for drop request ingestion diagnostics."""
     print(f"[DropRequestDebug] {message}")
+
+
+def _normalize_world_type(raw_world_type):
+    if raw_world_type is None:
+        return MAIN_WORLD_TYPE
+    normalized = str(raw_world_type).strip().lower()
+    return normalized or MAIN_WORLD_TYPE
+
+
+def _normalize_submission_type(raw_submission_type):
+    normalized = str(raw_submission_type or "").strip().lower()
+    match normalized:
+        case "other" | "npc":
+            return "drop"
+        case "kill_time" | "npc_kill":
+            return "personal_best"
+        case "experience_update" | "experience_milestone" | "level_up":
+            return "experience"
+        case "quest_completion":
+            return "quest"
+        case _:
+            return normalized
+
+
+def _dispatch_non_main_submission(world_type, submission_type):
+    """Route non-main submissions by type (currently no-op handlers)."""
+    match world_type:
+        case "seasonal":
+            match submission_type:
+                case (
+                    "drop"
+                    | "collection_log"
+                    | "personal_best"
+                    | "combat_achievement"
+                    | "experience"
+                    | "quest"
+                    | "pet"
+                    | "adventure_log"
+                ):
+                    # Seasonal routing placeholder for future handlers.
+                    pass
+                case _:
+                    pass
+        case _:
+            # Ignore all unsupported world types for now.
+            pass
 
 
 async def _link_video_to_submission(processed_data, db_session):
@@ -175,6 +222,15 @@ async def _process_webhook_request(req_start):
                         submission_type = processed_data.get("type")
                         g.submission_type = submission_type or g.submission_type
                         processed_data["downloaded"] = False
+                        world_type = _normalize_world_type(processed_data.get("world_type"))
+                        processed_data["world_type"] = world_type
+
+                        if world_type != MAIN_WORLD_TYPE:
+                            _dispatch_non_main_submission(
+                                world_type,
+                                _normalize_submission_type(submission_type),
+                            )
+                            continue
 
                         if image_file:
                             processed_data["has_image"] = True
@@ -320,6 +376,7 @@ async def process_webhook_data(webhook_data):
             }
             if not processed_data.get("timestamp"):
                 processed_data["timestamp"] = int(datetime.now().timestamp())
+            processed_data["world_type"] = _normalize_world_type(processed_data.get("world_type"))
             submission_type = str(processed_data.get("type", "")).lower()
             if submission_type in ("drop", "npc", "other"):
                 raw_nearby_players = processed_data.get("nearby_players")
@@ -366,6 +423,7 @@ async def process_webhook_data(webhook_data):
 # 2. MULTIPART FORM DATA - when an image file is uploaded:
 #    - All fields sent as form fields
 #    - Image sent as "image_file" field (CURLFile in PHP)
+# "world_type": string|null,  // Optional. Defaults to "main" when omitted.
 #
 # === DROP SUBMISSION FIELDS ===
 # submission_type: "drop"
@@ -542,6 +600,15 @@ async def _process_manual_submission(req_start):
                 "success": False, 
                 "error": f"Invalid submission_type: {submission_type}. Must be one of: {', '.join(valid_types)}"
             }), 400
+
+        world_type = _normalize_world_type(data.get("world_type"))
+        if world_type != MAIN_WORLD_TYPE:
+            _dispatch_non_main_submission(world_type, _normalize_submission_type(submission_type))
+            success = True
+            return jsonify({
+                "success": True,
+                "message": f"Ignored {submission_type} submission for world_type '{world_type}'"
+            }), 200
         
         # Generate a unique ID for this submission
         unique_id = str(uuid.uuid4())
@@ -557,6 +624,7 @@ async def _process_manual_submission(req_start):
             "guid": unique_id,
             "used_api": True,
             "downloaded": False,
+            "world_type": world_type,
             "image_url": data.get("image_url"),
             "timestamp": datetime.now().isoformat(),
         }

--- a/bots/webhook_bot.py
+++ b/bots/webhook_bot.py
@@ -48,6 +48,53 @@ bot = interactions.Client(token=bot_token, intents=Intents.ALL)
 metrics = MetricsTracker()
 watchdog = None
 shutdown_event = asyncio.Event()
+MAIN_WORLD_TYPE = "main"
+
+
+def _normalize_world_type(raw_world_type):
+    if raw_world_type is None:
+        return MAIN_WORLD_TYPE
+    normalized = str(raw_world_type).strip().lower()
+    return normalized or MAIN_WORLD_TYPE
+
+
+def _normalize_submission_type(raw_submission_type):
+    normalized = str(raw_submission_type or "").strip().lower()
+    match normalized:
+        case "other" | "npc":
+            return "drop"
+        case "kill_time" | "npc_kill":
+            return "personal_best"
+        case "experience_update" | "experience_milestone" | "level_up":
+            return "experience"
+        case "quest_completion":
+            return "quest"
+        case _:
+            return normalized
+
+
+def _dispatch_non_main_submission(world_type, submission_type):
+    """Route non-main submissions by type (currently no-op handlers)."""
+    match world_type:
+        case "seasonal":
+            match submission_type:
+                case (
+                    "drop"
+                    | "collection_log"
+                    | "personal_best"
+                    | "combat_achievement"
+                    | "experience"
+                    | "quest"
+                    | "pet"
+                    | "adventure_log"
+                ):
+                    # Seasonal routing placeholder for future handlers.
+                    pass
+                case _:
+                    pass
+        case _:
+            # Ignore unsupported world types for now.
+            pass
 
 RETRYABLE_DB_ERROR_STRINGS = (
     "server has gone away",
@@ -207,26 +254,33 @@ def retry_on_database_error(max_retries=3, delay=1):
 @retry_on_database_error(max_retries=3, delay=1)
 async def process_submission_with_session(submission_type, embed_data):
     """Process a submission with a fresh database session"""
+    world_type = _normalize_world_type(embed_data.get("world_type"))
+    embed_data["world_type"] = world_type
+    normalized_submission_type = _normalize_submission_type(submission_type)
     session = Session()
     try:
         success = False
-        if submission_type == "collection_log":
+        if world_type != MAIN_WORLD_TYPE:
+            _dispatch_non_main_submission(world_type, normalized_submission_type)
+            result = None
+            success = True
+        elif normalized_submission_type == "collection_log":
             print("Received collection log submission from non-api user")
             result = await clog_processor(embed_data, external_session=session)
             success = True
-        elif submission_type == "combat_achievement":
+        elif normalized_submission_type == "combat_achievement":
             result = await ca_processor(embed_data, external_session=session)
             success = True
-        elif submission_type == "personal_best":
+        elif normalized_submission_type == "personal_best":
             result = await pb_processor(embed_data, external_session=session)
             success = True
-        elif submission_type == "drop":
+        elif normalized_submission_type == "drop":
             result = await drop_processor(embed_data, external_session=session)
             success = True
-        elif submission_type == "pet":
+        elif normalized_submission_type == "pet":
             result = await pet_processor(embed_data, external_session=session)
             success = True
-        elif submission_type == "adventure_log":
+        elif normalized_submission_type == "adventure_log":
             result = await adventure_log_processor(embed_data, external_session=session)
             success = True
         else:
@@ -235,7 +289,7 @@ async def process_submission_with_session(submission_type, embed_data):
         # Commit the session if everything succeeded
         session.commit()
         try:
-            metrics.record_request(submission_type, success, app="webhook_bot")
+            metrics.record_request(normalized_submission_type, success, app="webhook_bot")
             #print(f"Recorded request: {submission_type} {success}")
         except Exception:
             #print(f"Error recording request: {submission_type} {success}")
@@ -250,7 +304,7 @@ async def process_submission_with_session(submission_type, embed_data):
             print(f"Rollback failed for {submission_type}: {rollback_error}")
         #print(f"Error processing {submission_type}: {e}")
         try:
-            metrics.record_request(submission_type, False, app="webhook_bot")
+            metrics.record_request(normalized_submission_type, False, app="webhook_bot")
         except Exception:
             pass
         raise

--- a/webhook_bot.py
+++ b/webhook_bot.py
@@ -28,6 +28,53 @@ bot = interactions.Client(token=os.getenv("WEBHOOK_TOKEN"), intents=Intents.ALL)
 metrics = MetricsTracker()
 watchdog = None
 shutdown_event = asyncio.Event()
+MAIN_WORLD_TYPE = "main"
+
+
+def _normalize_world_type(raw_world_type):
+    if raw_world_type is None:
+        return MAIN_WORLD_TYPE
+    normalized = str(raw_world_type).strip().lower()
+    return normalized or MAIN_WORLD_TYPE
+
+
+def _normalize_submission_type(raw_submission_type):
+    normalized = str(raw_submission_type or "").strip().lower()
+    match normalized:
+        case "other" | "npc":
+            return "drop"
+        case "kill_time" | "npc_kill":
+            return "personal_best"
+        case "experience_update" | "experience_milestone" | "level_up":
+            return "experience"
+        case "quest_completion":
+            return "quest"
+        case _:
+            return normalized
+
+
+def _dispatch_non_main_submission(world_type, submission_type):
+    """Route non-main submissions by type (currently no-op handlers)."""
+    match world_type:
+        case "seasonal":
+            match submission_type:
+                case (
+                    "drop"
+                    | "collection_log"
+                    | "personal_best"
+                    | "combat_achievement"
+                    | "experience"
+                    | "quest"
+                    | "pet"
+                    | "adventure_log"
+                ):
+                    # Seasonal routing placeholder for future handlers.
+                    pass
+                case _:
+                    pass
+        case _:
+            # Ignore unsupported world types for now.
+            pass
 
 # Health check function for systemd watchdog
 async def health_check():
@@ -124,25 +171,32 @@ def retry_on_database_error(max_retries=3, delay=1):
 @retry_on_database_error(max_retries=3, delay=1)
 async def process_submission_with_session(submission_type, embed_data):
     """Process a submission with a fresh database session"""
+    world_type = _normalize_world_type(embed_data.get("world_type"))
+    embed_data["world_type"] = world_type
+    normalized_submission_type = _normalize_submission_type(submission_type)
     session = Session()
     try:
         success = False
-        if submission_type == "collection_log":
+        if world_type != MAIN_WORLD_TYPE:
+            _dispatch_non_main_submission(world_type, normalized_submission_type)
+            result = None
+            success = True
+        elif normalized_submission_type == "collection_log":
             result = await clog_processor(embed_data, external_session=session)
             success = True
-        elif submission_type == "combat_achievement":
+        elif normalized_submission_type == "combat_achievement":
             result = await ca_processor(embed_data, external_session=session)
             success = True
-        elif submission_type == "personal_best":
+        elif normalized_submission_type == "personal_best":
             result = await pb_processor(embed_data, external_session=session)
             success = True
-        elif submission_type == "drop":
+        elif normalized_submission_type == "drop":
             result = await drop_processor(embed_data, external_session=session)
             success = True
-        elif submission_type == "pet":
+        elif normalized_submission_type == "pet":
             result = await pet_processor(embed_data, external_session=session)
             success = True
-        elif submission_type == "adventure_log":
+        elif normalized_submission_type == "adventure_log":
             result = await adventure_log_processor(embed_data, external_session=session)
             success = True
         else:
@@ -151,7 +205,7 @@ async def process_submission_with_session(submission_type, embed_data):
         # Commit the session if everything succeeded
         session.commit()
         try:
-            metrics.record_request(submission_type, success, app="webhook_bot")
+            metrics.record_request(normalized_submission_type, success, app="webhook_bot")
             #print(f"Recorded request: {submission_type} {success}")
         except Exception:
             #print(f"Error recording request: {submission_type} {success}")
@@ -163,7 +217,7 @@ async def process_submission_with_session(submission_type, embed_data):
         session.rollback()
         #print(f"Error processing {submission_type}: {e}")
         try:
-            metrics.record_request(submission_type, False, app="webhook_bot")
+            metrics.record_request(normalized_submission_type, False, app="webhook_bot")
         except Exception:
             pass
         raise
@@ -218,6 +272,7 @@ async def on_message_create(event: MessageCreate):
                     continue
                     
                 embed_data['used_api'] = False
+                embed_data["world_type"] = _normalize_world_type(embed_data.get("world_type"))
                 
                 try:
                     if "collection_log" in field_values:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `world_type` normalization (defaulting missing/empty values to `main`) for incoming webhook/API submission payloads
- keep existing main-world submission handlers intact while introducing explicit world-type dispatch for non-main submissions
- add seasonal world-type type-matching switch placeholders (currently `pass`) and ignore all other non-main world types
- apply equivalent world-type-aware behavior in both webhook bot implementations so API and bot ingestion paths are consistent

## Details
- `api/routes/webhook.py`
  - added `_normalize_world_type`, `_normalize_submission_type`, and `_dispatch_non_main_submission`
  - webhook ingest path now defaults `world_type` to `main` and skips processor execution for non-main world types via no-op dispatch
  - manual submit path now honors optional `world_type`, defaults to `main` when missing, and no-ops non-main submissions
  - documented optional `world_type` field in manual submission docs
- `webhook_bot.py` and `bots/webhook_bot.py`
  - added same normalization and non-main dispatch helpers
  - `process_submission_with_session` now routes only main-world submissions to existing processors
  - non-main world types are matched by normalized submission type and intentionally no-op

## Validation
- `python3 -m py_compile api/routes/webhook.py webhook_bot.py bots/webhook_bot.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aabd8c3d-25f0-4850-bb92-5774f8983a17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aabd8c3d-25f0-4850-bb92-5774f8983a17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

