### PR TITLE
Add temporary account hash support for WOM-imported group members

### DIFF
--- a/data/submissions/common.py
+++ b/data/submissions/common.py
@@ -273,6 +273,11 @@ class RawDropData:
         pass
 
 
+def _is_temp_account_hash(hash_value) -> bool:
+    """True when hash_value is a temporary placeholder assigned during WOM group import."""
+    return hash_value is not None and str(hash_value).startswith("wom_temp_")
+
+
 def check_auth(
     player_name,
     account_hash,
@@ -302,10 +307,35 @@ def check_auth(
             return False, False
 
         if player.account_hash:
-            if str(account_hash) != str(player.account_hash):
-                return True, False
-            else:
+            if str(account_hash) == str(player.account_hash):
                 return True, True
+            # A temporary WOM-import hash can be replaced by the player's real hash
+            # the first time they authenticate via the RuneLite plugin.
+            if _is_temp_account_hash(player.account_hash):
+                conflicting = (
+                    db_session.query(Player)
+                    .filter(Player.account_hash == str(account_hash))
+                    .first()
+                    if account_hash
+                    else None
+                )
+                if conflicting and conflicting.player_id != player.player_id:
+                    return True, False
+                player.account_hash = str(account_hash)
+                try:
+                    db_session.commit()
+                    app_logger.log(
+                        log_type="access",
+                        data=f"Replaced temporary account hash for {player_name} (wom_id={player.wom_id})",
+                        app_name="core",
+                        description="check_auth",
+                    )
+                except Exception as e:
+                    debug_print("Error replacing temp hash: " + str(e))
+                    db_session.rollback()
+                    return True, False
+                return True, True
+            return True, False
         else:
             # Never bind an account hash to a name-resolved row unless WOM identity was verified.
             if resolved_by_name:
@@ -528,14 +558,16 @@ async def ensure_player_and_auth(session, player_name, account_hash, auth_key):
                     debug_print("Error committing WOM identity reconciliation: " + str(e))
                     session.rollback()
 
-        # Hash conflicts are still treated as auth failures.
+        # Hash conflicts are auth failures, unless the stored hash is a temporary
+        # WOM-import placeholder — in that case check_auth() handles the replacement.
         if account_hash and player and player.account_hash and str(player.account_hash) != account_hash:
-            logger.log_sync(
-                "warning",
-                f"ensure_player_and_auth: hash mismatch for WOM {expected_wom_id}; refusing auth for {player_name}",
-            )
-            player_list[player_name] = player.player_id
-            return player, False, True
+            if not _is_temp_account_hash(player.account_hash):
+                logger.log_sync(
+                    "warning",
+                    f"ensure_player_and_auth: hash mismatch for WOM {expected_wom_id}; refusing auth for {player_name}",
+                )
+                player_list[player_name] = player.player_id
+                return player, False, True
     elif not player:
         # WOM unavailable + no deterministic local match.
         logger.log_sync(

--- a/db/ops.py
+++ b/db/ops.py
@@ -749,7 +749,13 @@ async def _sync_group_from_wom(group: Group, wom_id: int, on_add=None, on_remove
         removed (int): number of players removed
         skipped_removals (bool): True when removal pass was skipped due to incomplete WOM response
     """
-    group_wom_ids = await fetch_group_members(wom_id, force_refresh=True)
+    provision_cfg = session.query(GroupConfiguration).filter(
+        GroupConfiguration.group_id == group.group_id,
+        GroupConfiguration.config_key == "auto_provision_members",
+    ).first()
+    provision_missing = provision_cfg is not None and provision_cfg.config_value.lower() == "true"
+
+    group_wom_ids = await fetch_group_members(wom_id, force_refresh=True, provision_missing=provision_missing)
     if not group_wom_ids:
         print(f"Failed to fetch member list for group {group.group_name} (WOM ID: {wom_id})")
         return {"added": 0, "removed": 0, "skipped_removals": False}

--- a/utils/wiseoldman.py
+++ b/utils/wiseoldman.py
@@ -366,6 +366,7 @@ async def fetch_group_members(
                     # that created a new WOM identity) would cause the sync to incorrectly
                     # remove a valid group member. Try matching by player name to detect and
                     # correct this before the removal pass runs.
+                    player_by_name = None
                     if player_name:
                         player_by_name = (
                             session.query(Player)
@@ -386,6 +387,10 @@ async def fetch_group_members(
                                     player_name, commit_err,
                                 )
                                 session.rollback()
+                    if player_by_name is None:
+                        # Player has never used the plugin — create a stub with a temporary
+                        # account hash so they can be tracked in groups right away.
+                        _create_player_from_wom_member(session, member_wom_id, player_name, player_obj)
                 user_list.append(member_wom_id)
             await _store_group_cache(wom_group_id, user_list)
             return user_list
@@ -394,6 +399,45 @@ async def fetch_group_members(
     except Exception as e:
         print("Couldn't find WOM group members... Error:", e)
         return []
+
+def _create_player_from_wom_member(db_session, wom_id: int, player_name: Optional[str], player_obj=None) -> Optional[Player]:
+    """Create a Player record for a WOM group member with no local account.
+
+    The temporary account hash (wom_temp_<wom_id>) is replaced automatically
+    when the player first authenticates via the RuneLite plugin.
+    """
+    temp_hash = f"wom_temp_{wom_id}"
+    existing = db_session.query(Player).filter(Player.account_hash == temp_hash).first()
+    if existing:
+        return existing
+
+    total_level = 0
+    try:
+        if player_obj and getattr(player_obj, "latest_snapshot", None):
+            overall = player_obj.latest_snapshot.data.skills.get("overall")
+            if overall:
+                total_level = overall.level
+    except Exception:
+        pass
+
+    name = player_name or f"Unknown_{wom_id}"
+    new_player = Player(
+        wom_id=wom_id,
+        player_name=name,
+        account_hash=temp_hash,
+        total_level=total_level,
+        log_slots=0,
+    )
+    db_session.add(new_player)
+    try:
+        db_session.commit()
+        logger.info("Created WOM-imported player '%s' (wom_id=%s) with temporary hash", name, wom_id)
+        return new_player
+    except Exception as e:
+        logger.warning("Failed to create WOM-imported player '%s' (wom_id=%s): %s", name, wom_id, e)
+        db_session.rollback()
+        return None
+
 
 async def get_collections_logged(username: str):
     """

--- a/utils/wiseoldman.py
+++ b/utils/wiseoldman.py
@@ -284,11 +284,12 @@ async def fetch_group_members(
     session_to_use = None,
     *,
     force_refresh: bool = False,
-    use_cache: bool = True
+    use_cache: bool = True,
+    provision_missing: bool = False,
 ):
-    """ 
-    Returns a list of WiseOldMan Player IDs 
-    for members of a specified group 
+    """
+    Returns a list of WiseOldMan Player IDs
+    for members of a specified group
     """
     #print("Fetching group members for ID:", wom_group_id)
     user_list = []
@@ -387,7 +388,7 @@ async def fetch_group_members(
                                     player_name, commit_err,
                                 )
                                 session.rollback()
-                    if player_by_name is None:
+                    if player_by_name is None and provision_missing:
                         # Player has never used the plugin — create a stub with a temporary
                         # account hash so they can be tracked in groups right away.
                         _create_player_from_wom_member(session, member_wom_id, player_name, player_obj)


### PR DESCRIPTION
When syncing a WOM group, any member who has no existing player record
is now created automatically with a deterministic temporary account hash
(wom_temp_<wom_id>). This lets groups display stats and manual entries
for players who have never run the plugin.

When such a player authenticates for the first time via the RuneLite
plugin, the real account hash silently replaces the temporary one:
- check_auth() detects the wom_temp_ prefix and allows the override
  after verifying no other player already owns the incoming hash.
- The early-reject guard in ensure_player_and_auth() is skipped for
  temp hashes so check_auth() can perform the replacement.

