### PR TITLE
Fix Redis player sync broken by module-level add_to_player signature mismatch

### DIFF
--- a/data/submissions/drop.py
+++ b/data/submissions/drop.py
@@ -328,7 +328,7 @@ async def drop_processor(drop_data, external_session=None, world_type="main"):
             )
             debug_print("Player redis update completed")
         except Exception as e:
-            debug_print(f"Error updating player in redis: {e}")
+            print(f"[RedisSync] Failed to update player {player_id} in redis for drop {getattr(drop, 'drop_id', '?')}: {e}")
         log_checkpoint("redis_add_to_player")
 
         debug_print(f"Getting player groups for {player_name}...")

--- a/services/redis_updates.py
+++ b/services/redis_updates.py
@@ -898,9 +898,23 @@ def get_player_list_loot_sum(player_ids: List[int]):
         return 0
 
 # Convenience functions for backward compatibility
-def add_to_player(player: Player, drop: Drop, world_type: str = "main") -> bool:
+def add_to_player(
+    player: Player,
+    drop: Drop,
+    world_type: str = "main",
+    item_name: str | None = None,
+    npc_name: str | None = None,
+) -> bool:
     """Add a drop to a player's Redis cache"""
-    return loot_tracker.add_to_player(player, drop, world_type=world_type)
+    return loot_tracker.add_to_player(
+        player, drop, world_type=world_type, item_name=item_name, npc_name=npc_name,
+    )
+
+
+def add_split_credit(player_id: int, split_value: int, partition: int,
+                     group_id: int, world_type: str = "main") -> None:
+    """Adjust a player's score in a single group leaderboard by split_value."""
+    return loot_tracker.add_split_credit(player_id, split_value, partition, group_id, world_type)
 
 def force_update_player(player_id: int, session_to_use=None) -> bool:
     """Force update a player's Redis cache from database"""

--- a/tests/unit/test_redis_updates_wrappers.py
+++ b/tests/unit/test_redis_updates_wrappers.py
@@ -1,0 +1,87 @@
+"""
+Regression tests for the module-level convenience wrappers in
+services/redis_updates.py.
+
+data/submissions/drop.py imports the *module* (`from services import
+redis_updates`) and calls `redis_updates.add_to_player(...)` /
+`redis_updates.add_split_credit(...)` on it — not on the `loot_tracker`
+instance. Because the surrounding try/except in drop_processor swallows
+errors, a signature mismatch between the call site and the module-level
+wrapper silently disables all Redis player/leaderboard updates while the
+rest of the pipeline (DB row, notifications) keeps working.
+
+That exact failure shipped once: the RedisLootTracker.add_to_player METHOD
+gained `item_name`/`npc_name` kwargs, the call site in drop.py started
+passing them, but the module-level wrapper kept the old signature and every
+call raised TypeError. These tests load the real module (conftest stubs it
+in sys.modules for other tests) and pin the wrapper contracts.
+"""
+
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REAL_PATH = Path(__file__).resolve().parents[2] / "services" / "redis_updates.py"
+
+
+@pytest.fixture()
+def real_redis_updates():
+    """Load the real services/redis_updates.py despite the conftest stub."""
+    spec = importlib.util.spec_from_file_location("_real_redis_updates", _REAL_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_real_redis_updates"] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop("_real_redis_updates", None)
+
+
+class TestModuleLevelWrappers:
+    def test_add_to_player_accepts_drop_processor_call_signature(self, real_redis_updates):
+        """drop_processor passes item_name/npc_name — the wrapper must accept them."""
+        sig = inspect.signature(real_redis_updates.add_to_player)
+        # Must not raise TypeError:
+        sig.bind(
+            MagicMock(),  # player
+            MagicMock(),  # drop
+            world_type="main",
+            item_name="Twisted bow",
+            npc_name="Chambers of Xeric",
+        )
+
+    def test_add_to_player_forwards_to_loot_tracker(self, real_redis_updates):
+        tracker = MagicMock()
+        real_redis_updates.loot_tracker = tracker
+        player, drop = MagicMock(), MagicMock()
+
+        real_redis_updates.add_to_player(
+            player, drop, world_type="seasonal", item_name="Enhanced crystal weapon seed", npc_name="The Gauntlet",
+        )
+
+        tracker.add_to_player.assert_called_once_with(
+            player,
+            drop,
+            world_type="seasonal",
+            item_name="Enhanced crystal weapon seed",
+            npc_name="The Gauntlet",
+        )
+
+    def test_add_split_credit_exists_and_accepts_drop_processor_call_signature(self, real_redis_updates):
+        """_award_split_gp_credits calls redis_updates.add_split_credit(...) on the module."""
+        assert hasattr(real_redis_updates, "add_split_credit")
+        sig = inspect.signature(real_redis_updates.add_split_credit)
+        # Positional style used in drop.py:
+        sig.bind(123, -500000, 202607, 42, "main")
+
+    def test_add_split_credit_forwards_to_loot_tracker(self, real_redis_updates):
+        tracker = MagicMock()
+        real_redis_updates.loot_tracker = tracker
+
+        real_redis_updates.add_split_credit(123, 250000, 202607, 42, "main")
+
+        tracker.add_split_credit.assert_called_once_with(123, 250000, 202607, 42, "main")


### PR DESCRIPTION
drop_processor calls redis_updates.add_to_player() on the *module*, but
when RedisLootTracker.add_to_player gained item_name/npc_name kwargs for
the realtime drop feed, only the method was updated — the module-level
convenience wrapper kept the old (player, drop, world_type) signature.
Every call from drop_processor has since raised TypeError, which the
surrounding try/except swallowed with a debug-only message, so no drop
has updated player Redis totals or leaderboards while notifications kept
working.

- Forward item_name/npc_name through the module-level add_to_player wrapper
- Add the missing module-level add_split_credit wrapper (drop.py's split
  GP credits hit the same class-vs-module gap and raised AttributeError)
- Log Redis update failures in drop_processor unconditionally instead of
  behind the debug flag so this class of silent failure is visible
- Add regression tests that load the real services/redis_updates.py
  (conftest stubs it for other tests) and pin the wrapper signatures to
  the drop_processor call sites

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VLniDXQ6Xej4VNZ4K8Fz7c